### PR TITLE
エンティティをkernelに構造体として定義

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,9 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -876,6 +878,10 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "uuid",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1904,6 +1910,9 @@ name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ sqlx = { version = "0.8.2", features = [
     "migrate",
 ] }
 tokio = { version = "1.41.0", features = ["full"] }
+uuid = { version = "1.11.0", features = ["v4"] }
+chrono = "0.4.38"
 
 [dependencies]
 adapter.workspace = true

--- a/adapter/src/lib.rs
+++ b/adapter/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+uuid.workspace = true
+chrono.workspace = true

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,14 +1,30 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+pub struct User {
+    pub id: Uuid,
+    pub name: String,
+    pub email: String,
+    pub created_at: DateTime<Utc>,
+    pub update_at: DateTime<Utc>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub struct VirtualMachine {
+    pub id: Uuid,
+    pub name: String,
+    pub status: VirtualMachineStatus,
+    pub created_at: DateTime<Utc>,
+    pub update_at: DateTime<Utc>,
+    pub template_id: Uuid,
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+pub enum VirtualMachineStatus {}
+
+pub struct Template {
+    pub id: Uuid,
+    pub name: String,
+    pub iso: String,
+    pub core: usize,
+    pub memory: usize,
+    pub storage: usize,
 }


### PR DESCRIPTION
ひとまず、DB設計の際のエンティティをそのまま定義した。
VirtualMachinesのstatusに関しては、まだどんなステータスを採用するか決めていないので、空のVMStatus列挙子を定義した。
仕様決定次第、追記が必要である。