### PR TITLE
ProxmoxAPIのCloneメソッドの実装と型エイリアスの実装。

### DIFF
--- a/proxmox_api/src/lib.rs
+++ b/proxmox_api/src/lib.rs
@@ -4,6 +4,7 @@ use reqwest::{Client, Method, Response};
 use serde::{Deserialize, Serialize};
 
 use kernel::error::{ProxmoxApiError, ProxmoxApiResult};
+use proxmox_api::nodes::node::qemu::vmid::clone::PostParams as ClonePostParms;
 use proxmox_api::nodes::node::qemu::PostParams;
 use proxmox_api::version::GetOutput;
 
@@ -91,6 +92,37 @@ impl ProxmoxAPIClient {
                         .await
                         .map_err(ProxmoxApiWrapperError::from)?;
                     Ok(json)
+                } else {
+                    let status = response.status();
+                    let error_text = response
+                        .text()
+                        .await
+                        .unwrap_or_else(|_| "No response body".to_string());
+                    Err(ProxmoxApiError(anyhow::anyhow!(
+                        "Request failed with status {}: {}",
+                        status,
+                        error_text
+                    )))
+                }
+            }
+            Err(err) => Err(ProxmoxApiError(anyhow::anyhow!(
+                "Failed to send request: {}",
+                err
+            ))),
+        }
+    }
+
+    pub async fn clone_vm(
+        &self,
+        node: &str,
+        vmid: &str,
+        body: ClonePostParms,
+    ) -> ProxmoxApiResult<Response> {
+        let url = format!(" /{}/nodes/{}/qemu/{}/clone", self.base_url, node, vmid);
+        match self.post(&url, &body).await {
+            Ok(response) => {
+                if response.status().is_success() {
+                    Ok(response)
                 } else {
                     let status = response.status();
                     let error_text = response

--- a/proxmox_api/src/lib.rs
+++ b/proxmox_api/src/lib.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use kernel::error::{ProxmoxApiError, ProxmoxApiResult};
 use proxmox_api::nodes::node::qemu::vmid::clone::PostParams as ClonePostParms;
-use proxmox_api::nodes::node::qemu::PostParams;
-use proxmox_api::version::GetOutput;
+use proxmox_api::nodes::node::qemu::PostParams as CreateVirtualMachineRequest;
+use proxmox_api::version::GetOutput as VersionInfo;
 
 pub struct ProxmoxAPIClient {
     client: Client,
@@ -55,7 +55,7 @@ impl ProxmoxAPIClient {
     pub async fn create_virtual_machine(
         &self,
         node: &str,
-        body: &PostParams,
+        body: &CreateVirtualMachineRequest,
     ) -> ProxmoxApiResult<Response> {
         let path = format!("/nodes/{}/qemu", node);
 
@@ -83,11 +83,11 @@ impl ProxmoxAPIClient {
         }
     }
 
-    pub async fn get_version(&self) -> ProxmoxApiResult<GetOutput> {
+    pub async fn get_version(&self) -> ProxmoxApiResult<VersionInfo> {
         match self.get("/version").await {
             Ok(response) => {
                 if response.status().is_success() {
-                    let json: GetOutput = response
+                    let json: VersionInfo = response
                         .json()
                         .await
                         .map_err(ProxmoxApiWrapperError::from)?;


### PR DESCRIPTION
git resetで誤った部分を消してしまい、色々いじってたら訳わからんくなったので新しくPRを作成しました。

- Clone メソッドの引数としてこちらの構造体を使用しました。
[https://docs.rs/proxmoxapi/latest/proxmox_api/nodes/node/qemu/vmid/clone/struct.PostParams.html]

- 加えて、構造体明確化のため型エイリアスを追加しました。
