### PR TITLE
DELEATメソッド, PUTメソッド, get-vm-statusメソッドの実装

### DIFF
--- a/proxmox_api/src/lib.rs
+++ b/proxmox_api/src/lib.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use kernel::error::{ProxmoxApiError, ProxmoxApiResult};
 use proxmox_api::nodes::node::qemu::vmid::clone::PostParams as ClonePostParms;
+use proxmox_api::nodes::node::qemu::vmid::status::current::GetOutput as VirtualMachineStatus;
 use proxmox_api::nodes::node::qemu::PostParams as CreateVirtualMachineRequest;
 use proxmox_api::version::GetOutput as VersionInfo;
 
@@ -131,6 +132,43 @@ impl ProxmoxAPIClient {
             Ok(response) => {
                 if response.status().is_success() {
                     Ok(response)
+                } else {
+                    let status = response.status();
+                    let error_text = response
+                        .text()
+                        .await
+                        .unwrap_or_else(|_| "No response body".to_string());
+                    Err(ProxmoxApiError(anyhow::anyhow!(
+                        "Request failed with status {}: {}",
+                        status,
+                        error_text
+                    )))
+                }
+            }
+            Err(err) => Err(ProxmoxApiError(anyhow::anyhow!(
+                "Failed to send request: {}",
+                err
+            ))),
+        }
+    }
+
+    pub async fn get_vm_status(
+        &self,
+        node: &str,
+        vmid: &str,
+    ) -> ProxmoxApiResult<VirtualMachineStatus> {
+        let url = format!(
+            "/{}/nodes/{}/qemu/{}/status/current",
+            self.base_url, node, vmid
+        );
+        match self.get(&url).await {
+            Ok(response) => {
+                if response.status().is_success() {
+                    let json: VirtualMachineStatus = response
+                        .json()
+                        .await
+                        .map_err(ProxmoxApiWrapperError::from)?;
+                    Ok(json)
                 } else {
                     let status = response.status();
                     let error_text = response

--- a/proxmox_api/src/lib.rs
+++ b/proxmox_api/src/lib.rs
@@ -45,11 +45,19 @@ impl ProxmoxAPIClient {
     }
 
     async fn get(&self, path: &str) -> reqwest::Result<Response> {
-        self.request::<()>(Method::GET.clone(), path, None).await
+        self.request::<()>(Method::GET, path, None).await
     }
 
     async fn post<T: Serialize>(&self, path: &str, body: &T) -> reqwest::Result<Response> {
         self.request(Method::POST, path, Some(body)).await
+    }
+
+    async fn delete(&self, path: &str) -> reqwest::Result<Response> {
+        self.request::<()>(Method::DELETE, path, None).await
+    }
+
+    async fn put<T: Serialize>(&self, path: &str, body: &T) -> reqwest::Result<Response> {
+        self.request(Method::PUT, path, Some(body)).await
     }
 
     pub async fn create_virtual_machine(


### PR DESCRIPTION
get-vm-statusメソッドには以下の型を使用しました。
[https://docs.rs/proxmox-api/0.1.1/proxmox_api/nodes/node/qemu/vmid/status/current/struct.GetOutput.html]
Proxmox APIドキュメントのvm-statusのレスポンスのパラメータと同一だったため適切であると思いますが、一応確認お願いします。
[https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/status/current]


また、getメソッドの.cloneが不要とのことなので削除しました。

既存のコードのロジックを使っただけの簡単な実装なので、複数機能を一緒のPRにまとめることをお赦しください。