### PR TITLE
proxmox_apiクレート名の変更

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ name = "app"
 path = "src/main.rs"
 
 [workspace]
-members = ["api", "kernel", "adapter", "proxmox_api"]
+members = ["api", "kernel", "adapter", "pve_api"]
 
 [workspace.dependencies]
 adapter = { path = "./adapter" }
 api = { path = "./api" }
 kernel = { path = "./kernel" }
-proxmox_api = {path = "./proxmox_api" }
+pve_api = {path = "./pve_api" }
 axum = { version = "0.7.7", features = ["macros"] }
 reqwest = { version = "0.12.12", features = ["json", "rustls-tls"] }
 serde = { version = "1.0.217", features = ["derive"] }
@@ -42,3 +42,4 @@ axum.workspace = true
 sqlx.workspace = true
 anyhow.workspace = true
 proxmox-api.workspace = true
+pve_api.workspace = true

--- a/pve_api/Cargo.toml
+++ b/pve_api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "proxmox_api"
+name = "pve_api"
 version = "0.1.0"
 edition = "2021"
 

--- a/pve_api/src/lib.rs
+++ b/pve_api/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::format;
+
 use anyhow;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::{Client, Method, Response};
@@ -6,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use kernel::error::{ProxmoxApiError, ProxmoxApiResult};
 use proxmox_api::nodes::node::qemu::vmid::clone::PostParams as ClonePostParms;
 use proxmox_api::nodes::node::qemu::vmid::status::current::GetOutput as VirtualMachineStatus;
+use proxmox_api::nodes::node::qemu::vmid::template::PostParams as TemplateParms;
 use proxmox_api::nodes::node::qemu::PostParams as CreateVirtualMachineRequest;
 use proxmox_api::version::GetOutput as VersionInfo;
 


### PR DESCRIPTION
proxmox-apiライブラリを使用する際、cargo.tomlでの書き方がRustの記法に則りproxmox_apiという名前に変更され、proxmox_apiクレートと名前が被るため変更しました。